### PR TITLE
Feat/namdng09/manage order module

### DIFF
--- a/server/src/modules/address/addressController.ts
+++ b/server/src/modules/address/addressController.ts
@@ -26,9 +26,9 @@ export const addressController = {
    * addressController.show()
    */
   show: async (req: Request, res: Response): Promise<Response> => {
-    const { addressId } = req.params;
+    const { id } = req.params;
 
-    const address = await addressService.show(addressId);
+    const address = await addressService.show(id);
 
     return res
       .status(200)

--- a/server/src/modules/address/addressController.ts
+++ b/server/src/modules/address/addressController.ts
@@ -52,10 +52,10 @@ export const addressController = {
    * addressController.update()
    */
   update: async (req: Request, res: Response): Promise<Response> => {
-    const { addressId } = req.params;
+    const { id } = req.params;
     const addressData: IAddress = req.body;
 
-    const address = await addressService.update(addressId, addressData);
+    const address = await addressService.update(id, addressData);
 
     return res
       .status(200)
@@ -71,9 +71,9 @@ export const addressController = {
     next: NextFunction
   ): Promise<Response | void> => {
     try {
-      const { addressId } = req.params;
+      const { id } = req.params;
 
-      const address = await addressService.delete(addressId);
+      const address = await addressService.delete(id);
 
       return res
         .status(200)

--- a/server/src/modules/address/addressRoute.ts
+++ b/server/src/modules/address/addressRoute.ts
@@ -5,7 +5,7 @@ import { addressController } from './addressController';
 const router: Router = express.Router();
 
 router.get('/:userId/user', asyncHandler(addressController.list));
-router.get('/:addressId/address', asyncHandler(addressController.show));
+router.get('/:id', asyncHandler(addressController.show));
 
 router.post('/', asyncHandler(addressController.create));
 router.put('/:addressId', asyncHandler(addressController.update));

--- a/server/src/modules/address/addressRoute.ts
+++ b/server/src/modules/address/addressRoute.ts
@@ -8,7 +8,7 @@ router.get('/:userId/user', asyncHandler(addressController.list));
 router.get('/:id', asyncHandler(addressController.show));
 
 router.post('/', asyncHandler(addressController.create));
-router.put('/:addressId', asyncHandler(addressController.update));
-router.delete('/:addressId', asyncHandler(addressController.delete));
+router.put('/:id', asyncHandler(addressController.update));
+router.delete('/:id', asyncHandler(addressController.delete));
 
 export default router as Router;

--- a/server/src/modules/address/addressService.ts
+++ b/server/src/modules/address/addressService.ts
@@ -13,11 +13,11 @@ export const addressService = {
     return addresses;
   },
 
-  show: async (addressId: string) => {
-    if (!Types.ObjectId.isValid(addressId)) {
+  show: async (id: string) => {
+    if (!Types.ObjectId.isValid(id)) {
       throw createHttpError(400, 'Invalid address id');
     }
-    const address = await AddressModel.findById(addressId);
+    const address = await AddressModel.findById(id);
     if (!address) {
       throw createHttpError(404, 'Address not found');
     }

--- a/server/src/modules/address/addressService.ts
+++ b/server/src/modules/address/addressService.ts
@@ -82,8 +82,8 @@ export const addressService = {
     return newAddress;
   },
 
-  update: async (addressId: string, addressData: IAddress) => {
-    if (!Types.ObjectId.isValid(addressId)) {
+  update: async (id: string, addressData: IAddress) => {
+    if (!Types.ObjectId.isValid(id)) {
       throw createHttpError(400, 'Invalid address id');
     }
 
@@ -112,7 +112,7 @@ export const addressService = {
       );
     }
 
-    const address = await AddressModel.findById(addressId);
+    const address = await AddressModel.findById(id);
     if (!address) {
       throw createHttpError(404, 'Address not found');
     }
@@ -141,7 +141,7 @@ export const addressService = {
 
     if (isDefault === true && address.user) {
       await AddressModel.updateMany(
-        { user: address.user, _id: { $ne: addressId }, isDefault: true },
+        { user: address.user, _id: { $ne: id }, isDefault: true },
         { isDefault: false }
       );
     }
@@ -149,11 +149,11 @@ export const addressService = {
     return updatedAddress;
   },
 
-  delete: async (addressId: string) => {
-    if (!Types.ObjectId.isValid(addressId)) {
+  delete: async (id: string) => {
+    if (!Types.ObjectId.isValid(id)) {
       throw createHttpError(400, 'Invalid address id');
     }
-    const deletedAddress = await AddressModel.findByIdAndDelete(addressId);
+    const deletedAddress = await AddressModel.findByIdAndDelete(id);
     if (!deletedAddress) {
       throw createHttpError(404, 'Address not found');
     }

--- a/server/src/modules/order/orderService.ts
+++ b/server/src/modules/order/orderService.ts
@@ -97,6 +97,7 @@ export const orderService = {
         }
       },
       { $unwind: { path: '$user', preserveNullAndEmptyArrays: true } },
+
       {
         $lookup: {
           from: 'addresses',
@@ -105,6 +106,8 @@ export const orderService = {
           as: 'address'
         }
       },
+      { $unwind: { path: '$address', preserveNullAndEmptyArrays: true } },
+
       { $unwind: '$items' },
       {
         $lookup: {


### PR DESCRIPTION
This pull request introduces a consistent change across the `addressController`, `addressService`, and `addressRoute` to replace the parameter name `addressId` with `id` for better alignment and simplicity. Additionally, minor updates were made to the `orderService` to enhance query functionality.

### Address Module Changes:
* Updated `addressController` methods (`show`, `update`, `delete`) to use `id` instead of `addressId` for parameter names, ensuring consistency across the codebase. (`server/src/modules/address/addressController.ts`, [[1]](diffhunk://#diff-69eafc2c37c7fb91c3ca8ab5682739d9983cbfc0b8cebe39f62994fd3f0a06e1L29-R31) [[2]](diffhunk://#diff-69eafc2c37c7fb91c3ca8ab5682739d9983cbfc0b8cebe39f62994fd3f0a06e1L55-R58) [[3]](diffhunk://#diff-69eafc2c37c7fb91c3ca8ab5682739d9983cbfc0b8cebe39f62994fd3f0a06e1L74-R76)
* Modified `addressRoute` to reflect the parameter name change from `addressId` to `id` in route definitions. (`server/src/modules/address/addressRoute.ts`, [server/src/modules/address/addressRoute.tsL8-R12](diffhunk://#diff-3c833e2488854d09304e202a76fd00e3ae0582602acf0681f85dfa882443f1e9L8-R12))
* Refactored `addressService` methods (`show`, `update`, `delete`) to replace `addressId` with `id` and updated related logic, such as validation and database queries. (`server/src/modules/address/addressService.ts`, [[1]](diffhunk://#diff-dd0b8bc20221e6aee31cedd4f569ef727742804379b994b1bc48dfb53f43edb0L16-R20) [[2]](diffhunk://#diff-dd0b8bc20221e6aee31cedd4f569ef727742804379b994b1bc48dfb53f43edb0L85-R86) [[3]](diffhunk://#diff-dd0b8bc20221e6aee31cedd4f569ef727742804379b994b1bc48dfb53f43edb0L115-R115) [[4]](diffhunk://#diff-dd0b8bc20221e6aee31cedd4f569ef727742804379b994b1bc48dfb53f43edb0L144-R156)

### Order Module Changes:
* Added an `$unwind` stage for the `address` field in the `orderService` query pipeline to ensure proper handling of embedded documents. (`server/src/modules/order/orderService.ts`, [[1]](diffhunk://#diff-7cc75e6d7c27e424bff84a977907e1ce9c9ebe799c5f7593a4ce35986801b0b4R100) [[2]](diffhunk://#diff-7cc75e6d7c27e424bff84a977907e1ce9c9ebe799c5f7593a4ce35986801b0b4R109-R110)